### PR TITLE
Dockerfile - update to asciidoctor-pdf 1.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINERS="Guillaume Scheibel <guillaume.scheibel@gmail.com>, Damien DUP
 
 ARG asciidoctor_version=2.0.10
 ARG asciidoctor_confluence_version=0.0.2
-ARG asciidoctor_pdf_version=1.5.0.beta.7
+ARG asciidoctor_pdf_version=1.5.3
 ARG asciidoctor_diagram_version=1.5.19
 ARG asciidoctor_epub3_version=1.5.0.alpha.9
 ARG asciidoctor_mathematical_version=0.3.1


### PR DESCRIPTION
I tried building this locally and got the following when I ran asciidoctor-pdf in my local build:

```
/usr/lib/ruby/gems/2.5.0/gems/asciidoctor-pdf-1.5.0.beta.7/lib/asciidoctor/pdf/ext/ttfunk.rb:4:in `<class:Base>': undefined method `checksum' for class `TTFunk::Subset::Base' (NameError)
	from /usr/lib/ruby/gems/2.5.0/gems/asciidoctor-pdf-1.5.0.beta.7/lib/asciidoctor/pdf/ext/ttfunk.rb:3:in `<top (required)>'
	from /usr/lib/ruby/gems/2.5.0/gems/asciidoctor-pdf-1.5.0.beta.7/lib/asciidoctor/pdf/converter.rb:4:in `require_relative'
	from /usr/lib/ruby/gems/2.5.0/gems/asciidoctor-pdf-1.5.0.beta.7/lib/asciidoctor/pdf/converter.rb:4:in `<top (required)>'
	from /usr/lib/ruby/gems/2.5.0/gems/asciidoctor-pdf-1.5.0.beta.7/lib/asciidoctor/pdf.rb:5:in `require_relative'
	from /usr/lib/ruby/gems/2.5.0/gems/asciidoctor-pdf-1.5.0.beta.7/lib/asciidoctor/pdf.rb:5:in `<top (required)>'
	from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	from /usr/lib/ruby/gems/2.5.0/gems/asciidoctor-pdf-1.5.0.beta.7/bin/asciidoctor-pdf:5:in `<top (required)>'
	from /usr/bin/asciidoctor-pdf:23:in `load'
	from /usr/bin/asciidoctor-pdf:23:in `<main>'
```

From a quick search I found: https://github.com/asciidoctor/asciidoctor-pdf/issues/1461

hence suggestion of moving up to 1.5.3. Tested this locally and it worked.